### PR TITLE
Allow polling period to be set via ENV variable

### DIFF
--- a/haproxy.py
+++ b/haproxy.py
@@ -25,6 +25,7 @@ OPTION = os.getenv("OPTION", "redispatch, httplog, dontlognull, forwardfor").spl
 TIMEOUT = os.getenv("TIMEOUT", "connect 5000, client 50000, server 50000").split(",")
 VIRTUAL_HOST = os.getenv("VIRTUAL_HOST", None)
 TUTUM_CONTAINER_API_URL = os.getenv("TUTUM_CONTAINER_API_URL", None)
+POLLING_PERIOD = int(os.getenv("POLLING_PERIOD", 30))
 
 TUTUM_AUTH = os.getenv("TUTUM_AUTH")
 DEBUG = os.getenv("DEBUG", False)
@@ -32,7 +33,6 @@ DEBUG = os.getenv("DEBUG", False)
 # Const var
 CONFIG_FILE = '/etc/haproxy/haproxy.cfg'
 HAPROXY_CMD = ['/usr/sbin/haproxy', '-f', CONFIG_FILE, '-db']
-POLLING_PERIOD = 30
 LINK_ENV_PATTERN = "_PORT_%s_TCP" % PORT
 LINK_ADDR_SUFFIX = LINK_ENV_PATTERN + "_ADDR"
 LINK_PORT_SUFFIX = LINK_ENV_PATTERN + "_PORT"


### PR DESCRIPTION
When running an application the 30 second delay is quite a long time to wait once you've done a deployment of your linked containers.

This PR allows the `POLLING_PERIOD` variable to be assigned via the ENV param `POLLING_PERIOD`.

> I can see why this was most likely setup as a constant as it stops people hammering the tutum API from their containers by setting it to `1` but might make sense to have a min value of say `5` that it'll default to if the ENV param is lower than the min? 