### PR TITLE
Use the same options defaults

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ ENV BALANCE roundrobin
 ENV MAXCONN 4096
 
 # list of options separated by commas
-ENV OPTION redispatch, httplog, dontlognull
+ENV OPTION redispatch, httplog, dontlognull, forwardfor
 
 # list of timeout entries separated by commas
 ENV TIMEOUT connect 5000, client 50000, server 50000


### PR DESCRIPTION
Use the same options defaults in the Dockerfile that are used in the python start script.