### PR TITLE
Use environment variable PORT for binding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,8 +11,11 @@ RUN echo 'deb http://ppa.launchpad.net/vbernat/haproxy-1.5/ubuntu trusty main' >
     pip install requests==2.2.1 && \
     rm -rf /var/lib/apt/lists/*
 
-# PORT to load balance and to expose (also update the EXPOSE directive below)
-ENV PORT 80
+# BACKEND_PORT is the port of the app server which is load balanced (also update the EXPOSE directive below)
+ENV BACKEND_PORT 80
+
+# FRONTEND_PORT is the port on which the load balancer is accessible (also update the EXPOSE directive below)
+ENV FRONTEND_PORT 80
 
 # MODE of operation (http, tcp)
 ENV MODE http

--- a/README.md
+++ b/README.md
@@ -25,7 +25,8 @@ Configuration
 
 You can overwrite the following HAProxy configuration options:
 
-* `PORT` (default: `80`): The port where the web application backends are listening to.
+* `BACKEND_PORT` (default: `80`): The port where the web application backends are listening to.
+* `FRONTEND_PORT` (default: `80`): The port where the load balancer is listening to.
 * `MODE` (default: `http`): Mode of load balancing for HAProxy. Possible values include: `http`, `tcp`, `health`.
 * `BALANCE` (default: `roundrobin`): Load balancing algorithm to use. Possible values include: `roundrobin`, `static-rr`, `source`, `leastconn`.
 * `MAXCONN` (default: `4096`): Sets the maximum per-process number of concurrent connections.
@@ -54,13 +55,13 @@ Use case scenarios
 
 Use the following:
 
-    docker run -d --link webapp:webapp -e PORT=8080 -p 80:80 tutum/haproxy
+    docker run -d --link webapp:webapp -e BACKEND_PORT=8080 -p 80:80 tutum/haproxy
 
 #### My webapp container exposes port 80, and I want the proxy to listen in port 8080
 
 Use the following:
 
-    docker run -d --link webapp:webapp -e PORT=80 -p 8080:80 tutum/haproxy
+    docker run -d --link webapp:webapp -e FRONTEND_PORT=8080 -p 8080:8080 tutum/haproxy
 
 #### I want the proxy to terminate SSL connections and forward plain HTTP requests to my webapp to port 80
 
@@ -76,7 +77,7 @@ The certificate in `YOUR_CERT_TEXT` is a combination of public certificate and p
 
 Use the following:
 
-    docker run -d --link webapp:webapp -p 443:443 -e SSL_CERT="YOUR_CERT_TEXT" -e PORT=8080 tutum/haproxy
+    docker run -d --link webapp:webapp -p 443:443 -e SSL_CERT="YOUR_CERT_TEXT" -e BACKEND_PORT=8080 tutum/haproxy
 
 #### I want to use SSL and redirect non-SSL requests to the SSL endpoint
 

--- a/haproxy.py
+++ b/haproxy.py
@@ -100,7 +100,7 @@ def update_cfg(cfg, backend_routes, vhost):
     logger.debug("Updating cfg: \n old cfg: %s\n backend_routes: %s\n vhost: %s", cfg, backend_routes, vhost)
     # Set frontend
     frontend = []
-    frontend.append("bind 0.0.0.0:80")
+    frontend.append("bind 0.0.0.0:%s" % PORT)
     if SSL:
         frontend.append("redirect scheme https code 301 if !{ ssl_fc }"),
         frontend.append("bind 0.0.0.0:443 %s" % SSL)

--- a/haproxy.py
+++ b/haproxy.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 
 # Config ENV
 BACKEND_PORT = os.getenv("BACKEND_PORT", os.getenv("PORT", "80"))
-FRONTEND_PORT = os.getenv("FRONTEND_PORT", os.getenv("PORT", "80"))
+FRONTEND_PORT = os.getenv("FRONTEND_PORT", "80")
 MODE = os.getenv("MODE", "http")
 BALANCE = os.getenv("BALANCE", "roundrobin")
 MAXCONN = os.getenv("MAXCONN", "4096")

--- a/haproxy.py
+++ b/haproxy.py
@@ -15,7 +15,8 @@ import requests
 logger = logging.getLogger(__name__)
 
 # Config ENV
-PORT = os.getenv("PORT", "80")
+BACKEND_PORT = os.getenv("BACKEND_PORT", os.getenv("PORT", "80"))
+FRONTEND_PORT = os.getenv("FRONTEND_PORT", os.getenv("PORT", "80"))
 MODE = os.getenv("MODE", "http")
 BALANCE = os.getenv("BALANCE", "roundrobin")
 MAXCONN = os.getenv("MAXCONN", "4096")
@@ -33,7 +34,7 @@ DEBUG = os.getenv("DEBUG", False)
 # Const var
 CONFIG_FILE = '/etc/haproxy/haproxy.cfg'
 HAPROXY_CMD = ['/usr/sbin/haproxy', '-f', CONFIG_FILE, '-db']
-LINK_ENV_PATTERN = "_PORT_%s_TCP" % PORT
+LINK_ENV_PATTERN = "_PORT_%s_TCP" % BACKEND_PORT
 LINK_ADDR_SUFFIX = LINK_ENV_PATTERN + "_ADDR"
 LINK_PORT_SUFFIX = LINK_ENV_PATTERN + "_PORT"
 TUTUM_URL_SUFFIX = "_TUTUM_API_URL"
@@ -100,7 +101,7 @@ def update_cfg(cfg, backend_routes, vhost):
     logger.debug("Updating cfg: \n old cfg: %s\n backend_routes: %s\n vhost: %s", cfg, backend_routes, vhost)
     # Set frontend
     frontend = []
-    frontend.append("bind 0.0.0.0:%s" % PORT)
+    frontend.append("bind 0.0.0.0:%s" % FRONTEND_PORT)
     if SSL:
         frontend.append("redirect scheme https code 301 if !{ ssl_fc }"),
         frontend.append("bind 0.0.0.0:443 %s" % SSL)
@@ -267,7 +268,7 @@ if __name__ == "__main__":
                 backend_routes = {}
                 for link in container_details.get("linked_to_container", []):
                     for port, endpoint in link.get("endpoints", {}).iteritems():
-                        if port == "%s/tcp" % PORT:
+                        if port == "%s/tcp" % BACKEND_PORT:
                             backend_routes[link["name"]] = endpoint_match.match(endpoint).groupdict()
             else:
                 # No Tutum API access - configuring backends based on static environment variables


### PR DESCRIPTION
Using the environment variable PORT for binding the frontend, allows to use the HAProxy container for load balancing any service. 
As a proof of concept I set up load-balancing a pool of PHP FPMs behind a load-balanced pool of nginx instances: http://web-1.fabfuel.cont.tutum.io/

Best
Fabian