### PR TITLE
Fixed typo in log when launching

### DIFF
--- a/haproxy.py
+++ b/haproxy.py
@@ -214,7 +214,7 @@ def reload_haproxy():
         HAPROXY_CURRENT_SUBPROCESS = process
     else:
         # Launch haproxy
-        logger.info("Lauching haproxy")
+        logger.info("Launching haproxy")
         HAPROXY_CURRENT_SUBPROCESS = subprocess.Popen(HAPROXY_CMD)
 
 


### PR DESCRIPTION
This typo shows up in the container logs every time haproxy reloads/restarts.