### PR TITLE
Added support for defining SSL bind options and ciphers.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,9 @@ ENV VIRTUAL_HOST **None**
 # SSL certificate to use (optional)
 ENV SSL_CERT **None**
 
+# SSL bind options to use (optional)
+ENV SSL_BIND_OPTIONS no-sslv3
+
 # Add scripts
 ADD haproxy.py /haproxy.py
 ADD run.sh /run.sh

--- a/README.md
+++ b/README.md
@@ -33,6 +33,8 @@ You can overwrite the following HAProxy configuration options:
 * `OPTION` (default: `redispatch`): Comma-separated list of HAProxy `option` entries to the `default` section.
 * `TIMEOUT` (default: `connect 5000,client 50000,server 50000`): Comma-separated list of HAProxy `timeout` entries to the `default` section.
 * `SSL_CERT` (default: `**None**`): An optional certificate to use on the binded port. It should have both the private and public keys content. If set, port 443 will be used to handle HTTPS requests.
+* `SSL_BIND_OPTIONS` (default: `no-sslv3`): Optional. Explicitly set which SSL bind options will be used for the SSL server. This sets the HAProxy `ssl-default-bind-options` configuration setting. The default will allow only TLSv1.0+ to be used on the SSL server.
+* `SSL_BIND_CIPHERS` (default: `None`): Optional. Explicitly set which SSL ciphers will be used for the SSL server. This sets the HAProxy `ssl-default-bind-ciphers` configuration setting.
 * `VIRTUAL_HOST` (default: `**None**`): Optional. Let HAProxy route by domain name. Format `LINK_ALIAS=DOMAIN`, comma separated.
 
 Check [the HAProxy configuration manual](http://haproxy.1wt.eu/download/1.4/doc/configuration.txt) for more information on the above.

--- a/haproxy.py
+++ b/haproxy.py
@@ -21,6 +21,8 @@ MODE = os.getenv("MODE", "http")
 BALANCE = os.getenv("BALANCE", "roundrobin")
 MAXCONN = os.getenv("MAXCONN", "4096")
 SSL = os.getenv("SSL", "")
+SSL_BIND_OPTIONS = os.getenv("SSL_BIND_OPTIONS", None)
+SSL_BIND_CIPHERS = os.getenv("SSL_BIND_CIPHERS", None)
 SESSION_COOKIE = os.getenv("SESSION_COOKIE")
 OPTION = os.getenv("OPTION", "redispatch, httplog, dontlognull, forwardfor").split(",")
 TIMEOUT = os.getenv("TIMEOUT", "connect 5000, client 50000, server 50000").split(",")
@@ -73,6 +75,10 @@ def create_default_cfg(maxconn, mode):
     for timeout in TIMEOUT:
         if timeout:
             cfg["defaults"].append("timeout %s" % timeout.strip())
+    if SSL_BIND_OPTIONS:
+        cfg["global"].append("ssl-default-bind-options %s" % SSL_BIND_OPTIONS)
+    if SSL_BIND_CIPHERS:
+        cfg["global"].append("ssl-default-bind-ciphers %s" % SSL_BIND_CIPHERS)
 
     return cfg
 


### PR DESCRIPTION
This PR adds two new ENV vars to control SSL ciphers and SSL bind options within HAProxy.

The biggest change from this PR is that SSLv3 will now default to being disabled. This can be overridden though by nullifying the SSL_BIND_OPTIONS ENV var.

Closes #29.