### PR TITLE
Better tutum support

### DIFF
--- a/haproxy.py
+++ b/haproxy.py
@@ -97,8 +97,7 @@ def get_backend_routes_tutum(api_url, auth):
     addr_port_dict = {}
     for link in container_details.get("linked_to_container", []):
         for port, endpoint in link.get("endpoints", {}).iteritems():
-            if port == "%s/tcp" % BACKEND_PORT:
-                addr_port_dict[link["name"].upper().replace("-", "_")] = endpoint_match.match(endpoint).groupdict()
+            addr_port_dict[link["name"].upper().replace("-", "_")] = endpoint_match.match(endpoint).groupdict()
 
     return addr_port_dict
 

--- a/haproxy.py
+++ b/haproxy.py
@@ -86,8 +86,8 @@ def create_default_cfg(maxconn, mode):
 
 
 def get_backend_routes_tutum(api_url, auth):
-    # Return sth like: {'hello-world-1': {'proto': 'tcp', 'addr': '172.17.0.103', 'port': '80'},
-    # 'hello-world-2': {'proto': 'tcp', 'addr': '172.17.0.95', 'port': '80'}}
+    # Return sth like: {'HELLO_WORLD_1': {'proto': 'tcp', 'addr': '172.17.0.103', 'port': '80'},
+    # 'HELLO_WORLD_2': {'proto': 'tcp', 'addr': '172.17.0.95', 'port': '80'}}
     session = requests.Session()
     headers = {"Authorization": auth}
     r = session.get(api_url, headers=headers)
@@ -98,7 +98,7 @@ def get_backend_routes_tutum(api_url, auth):
     for link in container_details.get("linked_to_container", []):
         for port, endpoint in link.get("endpoints", {}).iteritems():
             if port == "%s/tcp" % BACKEND_PORT:
-                addr_port_dict[link["name"]] = endpoint_match.match(endpoint).groupdict()
+                addr_port_dict[link["name"].upper().replace("-", "_")] = endpoint_match.match(endpoint).groupdict()
 
     return addr_port_dict
 

--- a/haproxy.py
+++ b/haproxy.py
@@ -85,6 +85,24 @@ def create_default_cfg(maxconn, mode):
     return cfg
 
 
+def get_backend_routes_tutum(api_url, auth):
+    # Return sth like: {'hello-world-1': {'proto': 'tcp', 'addr': '172.17.0.103', 'port': '80'},
+    # 'hello-world-2': {'proto': 'tcp', 'addr': '172.17.0.95', 'port': '80'}}
+    session = requests.Session()
+    headers = {"Authorization": auth}
+    r = session.get(api_url, headers=headers)
+    r.raise_for_status()
+    container_details = r.json()
+
+    addr_port_dict = {}
+    for link in container_details.get("linked_to_container", []):
+        for port, endpoint in link.get("endpoints", {}).iteritems():
+            if port == "%s/tcp" % BACKEND_PORT:
+                addr_port_dict[link["name"]] = endpoint_match.match(endpoint).groupdict()
+
+    return addr_port_dict
+
+
 def get_backend_routes(dict_var):
     # Return sth like: {'HELLO_WORLD_1': {'addr': '172.17.0.103', 'port': '80'},
     # 'HELLO_WORLD_2': {'addr': '172.17.0.95', 'port': '80'}}
@@ -260,8 +278,6 @@ if __name__ == "__main__":
                 "an API role to this service for automatic backend reconfiguration")
     else:
         logger.info("HAproxy is not running in Tutum")
-    session = requests.Session()
-    headers = {"Authorization": TUTUM_AUTH}
 
     # Main loop
     old_text = ""
@@ -269,15 +285,7 @@ if __name__ == "__main__":
         try:
             if TUTUM_CONTAINER_API_URL and TUTUM_AUTH:
                 # Running on Tutum with API access - fetch updated list of environment variables
-                r = session.get(TUTUM_CONTAINER_API_URL, headers=headers)
-                r.raise_for_status()
-                container_details = r.json()
-
-                backend_routes = {}
-                for link in container_details.get("linked_to_container", []):
-                    for port, endpoint in link.get("endpoints", {}).iteritems():
-                        if port == "%s/tcp" % BACKEND_PORT:
-                            backend_routes[link["name"]] = endpoint_match.match(endpoint).groupdict()
+                backend_routes = get_backend_routes_tutum(TUTUM_CONTAINER_API_URL, TUTUM_AUTH)
             else:
                 # No Tutum API access - configuring backends based on static environment variables
                 backend_routes = get_backend_routes(os.environ)


### PR DESCRIPTION
This PR addresses three problems with the current tutum support. 

1. https://github.com/tutumcloud/tutum-docker-clusterproxy/commit/1f8bf1279378857d8d10500e3d4e543b21350f02 Structures the tutum-related code properly, so that it could be unit-tested
2. https://github.com/tutumcloud/tutum-docker-clusterproxy/commit/6231d89359f02aed310644541d6888885475493e Fixes the critical issue that the return format for backend_routes was different when using tutum api vs env vars
3. https://github.com/tutumcloud/tutum-docker-clusterproxy/commit/b59ee9137cc32835197a54dc29c0a9c2c8b1024d removes the filtering on BACKEND_PORT when using tutum api. It has no practical use and only prevented us from using backend services on different ports

I bundled them together. Let me know if you need three different issues reported and three different PRs. 

I'd add unit tests if there were some to begin with.

Sample stack yml file that would not work without these patches:

    web:
      # Does not work:
      #image: tutum/haproxy
      # Works:
      image: neam/tutum-haproxy-better-tutum-support
      links:
        - helloworld:helloworld
        - fooworld:fooworld
        - plantuml:plantuml
      ports:
      - "80:80"
      roles:
        - global
      environment:
        DEBUG: True

    # exposes port 80
    helloworld:
      image: tutum/hello-world
      environment:
        VIRTUAL_HOST: 'hello-world.X.X.X.X.xip.io'

    # exposes port 80
    fooworld:
      image: tutum/hello-world
      environment:
        VIRTUAL_HOST: 'fooworld.X.X.X.X.xip.io'

    # exposes port 8080
    plantuml:
      image: neam/plantuml-server
      environment:
        VIRTUAL_HOST: 'plantuml.X.X.X.X.xip.io'
